### PR TITLE
feat: Guideline about test locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,9 +208,9 @@ const App = props => (
 
 ## Tests
 
-Test files should be located next to their source file, rather then in a subfolder (for example `__tests__`).
+Unit test files should be located next to their source file, rather then in a subfolder (for example `__tests__`). This keeps them closer to their source file and encourages their maintenance.
 
-✅  Good
+:+1: Cool
 
 ```
 src
@@ -218,17 +218,6 @@ src
 │   └── components
 │        └── Greeting.jsx
 │        └── Greeting.spec.js
-```
-
-❌  Bad
-
-```
-src
-├── greetings
-│   └── components
-│        └── Greeting.js
-│        └── __tests__
-│            └── Greeting.spec.jsx
 ```
 
 </p>

--- a/README.md
+++ b/README.md
@@ -131,7 +131,6 @@ If you develop functionalities related to greetings, here is how you can structu
 src
 ├── greetings
 │   └── components
-│        └── __tests__
 │        └── Greeting.jsx
 │    └── redux
 │        └── index.js
@@ -205,6 +204,31 @@ const App = props => (
     <ConnectedGreeting />
   </Provider>
 )
+```
+
+## Tests
+
+Test files should be located next to their source file, rather then in a subfolder (for example `__tests__`).
+
+✅  Good
+
+```
+src
+├── greetings
+│   └── components
+│        └── Greeting.jsx
+│        └── Greeting.spec.js
+```
+
+❌  Bad
+
+```
+src
+├── greetings
+│   └── components
+│        └── Greeting.js
+│        └── __tests__
+│            └── Greeting.spec.jsx
 ```
 
 </p>


### PR DESCRIPTION
We alternate between having test files next to their source, and having them in `__tests__` folders. We should settle on one approach so we know where to look.

The most obvious place to look, is, i think, right next to the source file itself. Is that ok for everyone?